### PR TITLE
feat(messages): add user created message creator service

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -22,6 +22,12 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Modules/Users/Infrastructure/Persistence/Doctrine'
                 prefix: 'App\Modules\Users\Domain\Models'
                 alias: User
+            Message:
+                type: xml
+                is_bundle: false
+                dir: '%kernel.project_dir%/src/Modules/Messages/Infrastructure/Persistence/Doctrine'
+                prefix: 'App\Modules\Messages\Domain\Models'
+                alias: Message
         controller_resolver:
             auto_mapping: true
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -15,3 +15,6 @@ services:
     App\Modules\Users\Infrastructure\Controllers\UserPostController:
         public: true
         tags: ['controller.service_arguments']
+
+    App\Modules\Messages\Application\Services\UserCreatedMessageCreator:
+        tags: [messenger.message_handler]

--- a/migrations/Version20240428125619.php
+++ b/migrations/Version20240428125619.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240428125619 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Creates message table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('
+            CREATE TABLE message (id BINARY(16) NOT NULL COMMENT \'(DC2Type:uuid)\', 
+            eventId VARCHAR(100) NOT NULL, 
+            eventName VARCHAR(100) NOT NULL, 
+            attributes JSON NOT NULL, 
+            created_at DATETIME NOT NULL, 
+            updated_at DATETIME NOT NULL, 
+            UNIQUE INDEX UNIQ_B6BD307F2B2EBB6C (eventId), 
+            PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE message');
+    }
+}

--- a/src/Modules/Messages/Application/Services/UserCreatedMessageCreator.php
+++ b/src/Modules/Messages/Application/Services/UserCreatedMessageCreator.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Modules\Messages\Application\Services;
+
+use App\Modules\Messages\Domain\Models\Message;
+use App\Modules\Messages\Domain\Repositories\MessageRepository;
+use App\Modules\Users\Domain\Events\UserCreatedDomainEvent;
+use Exception;
+use Psr\Log\LoggerInterface;
+
+class UserCreatedMessageCreator
+{
+    public function __construct(
+        private LoggerInterface $logger,
+        private MessageRepository $repository
+    ){}
+
+    public function __invoke(UserCreatedDomainEvent $event): void
+    {
+        $this->logger->info(sprintf('Handling user created domain event %s', $event->getEventId()));
+
+        $message = Message::create($event->getEventId(), $event->getEventName(), $event->getAttributes());
+
+        try {
+            $this->repository->save($message);
+        }catch (Exception $exception) {
+            $this->logger->error(sprintf('Error handling user created event %s: %s', $event->getEventId(), $exception->getMessage()));
+        }
+    }
+}

--- a/src/Modules/Messages/Domain/Models/Message.php
+++ b/src/Modules/Messages/Domain/Models/Message.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Modules\Messages\Domain\Models;
+
+
+use App\Modules\Shared\Application\Services\Uuid;
+use DateTime;
+
+class Message
+{
+    private string $id;
+
+    private string $eventId;
+
+    private string $eventName;
+
+    private string $attributes;
+
+    private DateTime $createdAt;
+
+    private DateTime $updatedAt;
+
+    public function __construct(string $eventId, string $eventName, string $attributes)
+    {
+        $this->id = Uuid::generate();
+        $this->eventId = $eventId;
+        $this->eventName = $eventName;
+        $this->attributes = $attributes;
+        $this->createdAt = new DateTime();
+        $this->updatedAt = new DateTime();
+    }
+
+    public static function create(string $eventId, string $eventName, string $attributes): self
+    {
+        return new self($eventId, $eventName, $attributes);
+    }
+}

--- a/src/Modules/Messages/Domain/Repositories/MessageRepository.php
+++ b/src/Modules/Messages/Domain/Repositories/MessageRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Modules\Messages\Domain\Repositories;
+
+use App\Modules\Messages\Domain\Models\Message;
+
+interface MessageRepository
+{
+    public function save(Message $message): void;
+}

--- a/src/Modules/Messages/Infrastructure/Persistence/Doctrine/Message.orm.xml
+++ b/src/Modules/Messages/Infrastructure/Persistence/Doctrine/Message.orm.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping">
+    <entity name="App\Modules\Messages\Domain\Models\Message" table="message">
+        <id name="id" type="uuid" />
+        <field name="eventId" column="eventId" length="100" unique="true" />
+        <field name="eventName" column="eventName" length="100" />
+        <field name="attributes" type="json" column="attributes" />
+        <field name="createdAt" type="datetime" column="created_at" />
+        <field name="updatedAt" type="datetime" column="updated_at" />
+    </entity>
+</doctrine-mapping>

--- a/src/Modules/Messages/Infrastructure/Persistence/DoctrineMessageRepository.php
+++ b/src/Modules/Messages/Infrastructure/Persistence/DoctrineMessageRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Modules\Messages\Infrastructure\Persistence;
+
+use App\Modules\Messages\Domain\Models\Message;
+use App\Modules\Messages\Domain\Repositories\MessageRepository;
+use App\Modules\Shared\Infrastructure\Persistence\DoctrineRepository;
+
+class DoctrineMessageRepository extends DoctrineRepository implements MessageRepository
+{
+
+    public function save(Message $message): void
+    {
+        $this->persist($message);
+    }
+}

--- a/src/Modules/Users/Domain/Events/UserCreatedDomainEvent.php
+++ b/src/Modules/Users/Domain/Events/UserCreatedDomainEvent.php
@@ -10,19 +10,46 @@ class UserCreatedDomainEvent
 {
     private string $eventId;
 
+    private string $eventName;
+
     private DateTime $occurred_on;
 
-    private object $attributes;
+    private string $attributes;
 
-    public function __construct(object $attributes)
+    public function __construct(User $user)
     {
         $this->eventId = Uuid::generate();
+        $this->eventName = 'user.created';
         $this->occurred_on = new DateTime();
-        $this->attributes = $attributes;
+        $this->attributes = $this->serializeAttributes($user);
     }
 
     public static function create(User $user): self
     {
         return new self($user);
+    }
+
+    public function getEventId(): string
+    {
+        return $this->eventId;
+    }
+
+    public function getEventName(): string
+    {
+        return $this->eventName;
+    }
+
+    public function getAttributes(): string
+    {
+        return $this->attributes;
+    }
+
+    private function serializeAttributes(User $user): string
+    {
+        return json_encode([
+            'id' => $user->getId(),
+            'name' => $user->getName(),
+            'email' => $user->getEmail(),
+        ], JSON_THROW_ON_ERROR);
     }
 }

--- a/src/Modules/Users/Domain/Models/User.php
+++ b/src/Modules/Users/Domain/Models/User.php
@@ -33,6 +33,21 @@ class User
         return new self($id, $name, $email, $password);
     }
 
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
     public function getPassword(): string
     {
         return $this->password;


### PR DESCRIPTION
## :boom: Resumen
Se ha implementado el **caso de uso creación de mensaje**.

*Cuando se crea un nuevo usuario, se lanza un evento de dominio al cual está suscrito el caso de uso `UserCreatedMessageCreator`, que ejecutará la lógica de negocio necesaria para guardar un registro en base de datos.*